### PR TITLE
README dependencies and spelling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,22 @@
+ History files
+.Rhistory
+.Rapp.history
+
+# Session Data files
+.RData
+.RDataTmp
+
+# User-specific files
+.Ruserdata
+
+# Example code in package build process
+*-Ex.R
+
+# RStudio files
+.Rproj.user/
 
 outputs/cleaned ssni coverage (2017).csv
 .Rproj.user
+
+# RStudio Connect folder
+rsconnect/

--- a/README.md
+++ b/README.md
@@ -36,6 +36,6 @@ This data is available on GitHub along with code preparation code: https://githu
 
 One key dataset is not shared in this repo but described below:
 
-- Development of Sure Start Coverage Table.XLSX: This was sent by the NI Department of Education. Worksheet 1 contains their records of Sure Start areas and theri timing. Worksheet 2 is a cleaned and reformatted version which contains key variables:
+- Development of Sure Start Coverage Table.XLSX: This was sent by the NI Department of Education. Worksheet 1 contains their records of Sure Start areas and their timing. Worksheet 2 is a cleaned and reformatted version which contains key variables:
   - soa_nimd: name of SOA for linkage to imd
   - Phase.included: which phase a particular SOA was included

--- a/README.md
+++ b/README.md
@@ -4,9 +4,14 @@ Data and code to used to produce the analysis used in the Sure Start protocol an
 
 # How to use 
 
-1. Run the code in the `makeFiles` folder to get cleaned version of the raw data (stored in `outputs`). 
-2. Files in the main folder with the prefix `protocol` do the analysis (saved in `ouputs`). 
-3. (optional) Files with the prefix `source` contain code for specific repetitive analysis tasks (e.g. make graphs, run models). 
+1. Install R dependencies
+
+```{r}
+install.packages(c("tidyverse", "rJava", "xlsx"))
+```
+2. Run the code in the `makeFiles` folder to get cleaned version of the raw data (stored in `outputs`). 
+3. Files in the main folder with the prefix `protocol` do the analysis (saved in `outputs`). 
+4. (optional) Files with the prefix `source` contain code for specific repetitive analysis tasks (e.g. make graphs, run models).
 
 # Data
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Data and code to used to produce the analysis used in the Sure Start protocol an
 1. Install R dependencies
 
 ```{r}
-install.packages(c("tidyverse", "rJava", "xlsx"))
+install.packages(c("tidyverse", "rJava", "xlsx", "rdd", "rddtools"))
 ```
 2. Run the code in the `makeFiles` folder to get cleaned version of the raw data (stored in `outputs`). 
 3. Files in the main folder with the prefix `protocol` do the analysis (saved in `outputs`). 

--- a/makeFiles/makeFile cleaned nimdm 2005 scores (wards).R
+++ b/makeFiles/makeFile cleaned nimdm 2005 scores (wards).R
@@ -68,7 +68,7 @@ mdmScore_df <-
 mdmScore_df %>% 
   rename(
     ward_name = Ward,
-    ward_code = Ward.Code
+    ward_code = `Ward Code`
     ) %>%
   select(ward_code, ward_name, mdm_rank_2005, mdm_score_2005, k_nimdm2005) %>%
   write_csv('outputs/cleaned nimdm 2005 scores (wards).csv')

--- a/makeFiles/makeFile cleaned ssni coverage data (DE 2017).R
+++ b/makeFiles/makeFile cleaned ssni coverage data (DE 2017).R
@@ -2,17 +2,19 @@
 # notes reading in the data 
 
 library(tidyverse)
-library(rJava)
-library(xlsx)
 
 # input/ output -----------------------------------------------------------
 
 ## Sure Start data
 
+### GJG - this required an rJava dependency just for the single line of code, so
+### so I've replaced with readxl::read_xlsx, for ease of reproducibility
+
 ## The raw file from ni gov is in worksheet 1 and i reformatted 
 ssni_df <-
   'cleaned data/Development of Sure Start Coverage Table.XLSX' %>%
-  read.xlsx(2)
+  readxl::read_xlsx(2)
+
 
 nimdm2010_df <- 
   readxl::read_xls('data/NIMDM 2010 soa.xls', sheet = 2)


### PR DESCRIPTION
MLZ to check element update 15fcd0e doesn't create issue with the ssni file, as not in main datasets. 

Removing xlsx package removes need for Java dependency, so easier to run & fewer packages - but easy to tweak to reinstall this

rJava and xlsx still listed in package dependencies on the README in case of conflict